### PR TITLE
Add Datetime and Byte support

### DIFF
--- a/src/GraphQlClientGenerator/GraphQlGenerator.cs
+++ b/src/GraphQlClientGenerator/GraphQlGenerator.cs
@@ -228,6 +228,9 @@ using System.Text;
                         case "Int":
                             propertyType = "int?";
                             break;
+                        case "Byte":
+                            propertyType = "byte?";
+                            break;
                         case "String":
                             propertyType = GraphQlGeneratorConfiguration.CustomScalarFieldTypeMapping(baseType, fieldType, member.Name);
                             break;
@@ -553,6 +556,8 @@ using System.Text;
             {
                 case GraphQlTypeBase.GraphQlTypeScalarInteger:
                     return "int?";
+                case GraphQlTypeBase.GraphQlTypeScalarByte:
+                    return "byte?";
                 case GraphQlTypeBase.GraphQlTypeScalarString:
                     return GraphQlGeneratorConfiguration.CustomScalarFieldTypeMapping(baseType, valueType, valueName);
                 case GraphQlTypeBase.GraphQlTypeScalarFloat:

--- a/src/GraphQlClientGenerator/GraphQlGenerator.cs
+++ b/src/GraphQlClientGenerator/GraphQlGenerator.cs
@@ -240,6 +240,9 @@ using System.Text;
                         case "ID":
                             propertyType = "Guid?";
                             break;
+                        case "DateTime":
+                            propertyType = "DateTime?";
+                            break;
                         default:
                             propertyType = GraphQlGeneratorConfiguration.CustomScalarFieldTypeMapping(baseType, fieldType, member.Name);
                             break;
@@ -558,6 +561,8 @@ using System.Text;
                     return "bool?";
                 case GraphQlTypeBase.GraphQlTypeScalarId:
                     return "Guid?";
+                case GraphQlTypeBase.GraphQlTypeScalarDateTime:
+                    return "DateTime?";
                 default:
                     return GraphQlGeneratorConfiguration.CustomScalarFieldTypeMapping(baseType, valueType, valueName);
             }

--- a/src/GraphQlClientGenerator/GraphQlIntrospectionSchema.cs
+++ b/src/GraphQlClientGenerator/GraphQlIntrospectionSchema.cs
@@ -82,6 +82,7 @@ namespace GraphQlClientGenerator
         public const string GraphQlTypeScalarFloat = "Float";
         public const string GraphQlTypeScalarId = "ID";
         public const string GraphQlTypeScalarInteger = "Int";
+        public const string GraphQlTypeScalarByte = "Byte";
         public const string GraphQlTypeScalarString = "String";
         public const string GraphQlTypeScalarDateTime = "DateTime";
 

--- a/src/GraphQlClientGenerator/GraphQlIntrospectionSchema.cs
+++ b/src/GraphQlClientGenerator/GraphQlIntrospectionSchema.cs
@@ -83,6 +83,7 @@ namespace GraphQlClientGenerator
         public const string GraphQlTypeScalarId = "ID";
         public const string GraphQlTypeScalarInteger = "Int";
         public const string GraphQlTypeScalarString = "String";
+        public const string GraphQlTypeScalarDateTime = "DateTime";
 
         public string Kind { get; set; }
         public string Name { get; set; }


### PR DESCRIPTION
### Changes

- Add DateTime support
- Add Byte support


### Details

This allows types such as:
```
public class OrderType
{
    public DateTime? CreatedDateTimeUtc { get; set; }
    public byte? SomeSmallNumber { get; set; }
}
```

vs 

```
public class OrderType
{
    public object CreatedDateTimeUtc { get; set; }
    public object SomeSmallNumber { get; set; }
}
```