### PR TITLE
Use ordinal comparison in dictionaries.

### DIFF
--- a/src/GraphQlClientGenerator/GraphQlGenerator.cs
+++ b/src/GraphQlClientGenerator/GraphQlGenerator.cs
@@ -649,7 +649,7 @@ using Newtonsoft.Json.Linq;
             if (args.Count == 0)
                 return;
 
-            builder.AppendLine("        var args = new Dictionary<string, object>();");
+            builder.AppendLine("        var args = new Dictionary<string, object>(StringComparer.Ordinal);");
 
             foreach (var arg in args)
             {


### PR DESCRIPTION
Instead of the default comparer of a dictionary, this change ensures all generated code uses the ordinal string comparer. This comparer is faster and can be used since the keys are known to be developer-facing keys that have no culture-specific information attached to them.