### PR TITLE
Make base GraphQlQueryBuilder partial

### DIFF
--- a/src/GraphQlClientGenerator/BaseClasses.cs
+++ b/src/GraphQlClientGenerator/BaseClasses.cs
@@ -540,7 +540,7 @@ public abstract class GraphQlDirective
     }
 }
 
-public abstract class GraphQlQueryBuilder : IGraphQlQueryBuilder
+public abstract partial class GraphQlQueryBuilder : IGraphQlQueryBuilder
 {
     private readonly Dictionary<string, GraphQlFieldCriteria> _fieldCriteria = new Dictionary<string, GraphQlFieldCriteria>();
 
@@ -841,7 +841,7 @@ public abstract class GraphQlQueryBuilder : IGraphQlQueryBuilder
     }
 }
 
-public abstract class GraphQlQueryBuilder<TQueryBuilder> : GraphQlQueryBuilder where TQueryBuilder : GraphQlQueryBuilder<TQueryBuilder>
+public abstract partial class GraphQlQueryBuilder<TQueryBuilder> : GraphQlQueryBuilder where TQueryBuilder : GraphQlQueryBuilder<TQueryBuilder>
 {
     protected GraphQlQueryBuilder(string operationType = null, string operationName = null) : base(operationType, operationName)
     {

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/FullClientCSharpFile
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/FullClientCSharpFile
@@ -560,7 +560,7 @@ namespace GraphQlGenerator.Test
         }
     }
     
-    public abstract class GraphQlQueryBuilder : IGraphQlQueryBuilder
+    public abstract partial class GraphQlQueryBuilder : IGraphQlQueryBuilder
     {
         private readonly Dictionary<string, GraphQlFieldCriteria> _fieldCriteria = new Dictionary<string, GraphQlFieldCriteria>();
     
@@ -861,7 +861,7 @@ namespace GraphQlGenerator.Test
         }
     }
     
-    public abstract class GraphQlQueryBuilder<TQueryBuilder> : GraphQlQueryBuilder where TQueryBuilder : GraphQlQueryBuilder<TQueryBuilder>
+    public abstract partial class GraphQlQueryBuilder<TQueryBuilder> : GraphQlQueryBuilder where TQueryBuilder : GraphQlQueryBuilder<TQueryBuilder>
     {
         protected GraphQlQueryBuilder(string operationType = null, string operationName = null) : base(operationType, operationName)
         {

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResult
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResult
@@ -560,7 +560,7 @@ namespace SourceGeneratorTestAssembly
         }
     }
     
-    public abstract class GraphQlQueryBuilder : IGraphQlQueryBuilder
+    public abstract partial class GraphQlQueryBuilder : IGraphQlQueryBuilder
     {
         private readonly Dictionary<string, GraphQlFieldCriteria> _fieldCriteria = new Dictionary<string, GraphQlFieldCriteria>();
     
@@ -861,7 +861,7 @@ namespace SourceGeneratorTestAssembly
         }
     }
     
-    public abstract class GraphQlQueryBuilder<TQueryBuilder> : GraphQlQueryBuilder where TQueryBuilder : GraphQlQueryBuilder<TQueryBuilder>
+    public abstract partial class GraphQlQueryBuilder<TQueryBuilder> : GraphQlQueryBuilder where TQueryBuilder : GraphQlQueryBuilder<TQueryBuilder>
     {
         protected GraphQlQueryBuilder(string operationType = null, string operationName = null) : base(operationType, operationName)
         {


### PR DESCRIPTION
This allows extending base classes. For example, the following method, in contrast to `WithAllScalarFields`, will also include the list of scalars.
```csharp
public partial class GraphQlQueryBuilder<TQueryBuilder>
{
    public TQueryBuilder WithAllSimpleFields()
    {
        IncludeFields(AllFields.Where(f => f.QueryBuilderType == null));
        return (TQueryBuilder)this;
    }
}
```