### PR TITLE
Always request __typename for interfaces and unions

### DIFF
--- a/src/GraphQlClientGenerator/GraphQlGenerator.cs
+++ b/src/GraphQlClientGenerator/GraphQlGenerator.cs
@@ -1079,6 +1079,20 @@ using Newtonsoft.Json.Linq;
         else
             directiveLocation = GraphQlDirectiveLocation.Field;
 
+        if (type.Kind is GraphQlTypeKind.Interface or GraphQlTypeKind.Union)
+        {
+            var constructorIndentation = indentation + "    ";
+            writer.Write(constructorIndentation);
+            writer.WriteLine($"public {className}()");
+            writer.Write(constructorIndentation);
+            writer.WriteLine("{");
+            writer.Write(constructorIndentation);
+            writer.WriteLine("    WithTypeName();");
+            writer.Write(constructorIndentation);
+            writer.WriteLine("}");
+            writer.WriteLine();
+        }
+
         var hasQueryPrefix = directiveLocation != GraphQlDirectiveLocation.Field;
 
         WriteOverrideProperty("protected", "string", "TypeName", $"\"{type.Name}\"", indentation, writer);

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/FormatMasks
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/FormatMasks
@@ -1282,6 +1282,11 @@ public partial class PageInfoQueryBuilder : GraphQlQueryBuilder<PageInfoQueryBui
             new GraphQlFieldMetadata { Name = "startCursor" }
         };
 
+    public PageInfoQueryBuilder()
+    {
+        WithTypeName();
+    }
+
     protected override string TypeName { get { return "PageInfo"; } } 
 
     public override IReadOnlyList<GraphQlFieldMetadata> AllFields { get { return AllFieldMetadata; } } 

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResult
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResult
@@ -1746,6 +1746,11 @@ namespace SourceGeneratorTestAssembly
             new GraphQlFieldMetadata { Name = "startCursor" }
         };
 
+        public SourceGeneratedPageInfoQueryBuilderV2()
+        {
+            WithTypeName();
+        }
+
         protected override string TypeName { get; } = "PageInfo";
 
         public override IReadOnlyList<GraphQlFieldMetadata> AllFields { get; } = AllFieldMetadata;

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/Unions
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/Unions
@@ -114,6 +114,11 @@ public partial class UnionTypeQueryBuilder : GraphQlQueryBuilder<UnionTypeQueryB
 {
     private static readonly GraphQlFieldMetadata[] AllFieldMetadata = new GraphQlFieldMetadata[0];
 
+    public UnionTypeQueryBuilder()
+    {
+        WithTypeName();
+    }
+
     protected override string TypeName { get; } = "UnionType";
 
     public override IReadOnlyList<GraphQlFieldMetadata> AllFields { get; } = AllFieldMetadata;
@@ -131,6 +136,11 @@ public partial class NamedTypeQueryBuilder : GraphQlQueryBuilder<NamedTypeQueryB
     {
         new GraphQlFieldMetadata { Name = "name" }
     };
+
+    public NamedTypeQueryBuilder()
+    {
+        WithTypeName();
+    }
 
     protected override string TypeName { get; } = "NamedType";
 


### PR DESCRIPTION
It makes sense to always request __typename for interfaces and unions. We can ignore the alias here because the name `__typename` is hardcoded in `GraphQlInterfaceJsonConverter`.