### PR TITLE
#137 Escape Newlines in GraphQL String Values

### DIFF
--- a/src/GraphQlClientGenerator/BaseClasses.cs
+++ b/src/GraphQlClientGenerator/BaseClasses.cs
@@ -147,7 +147,9 @@ internal static class GraphQlQueryHelper
 
     public static string EscapeGraphQlStringValue(string value)
     {
-        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        var escaped = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+        return $"\"\"\"{escaped}\"\"\"";
     }
 
     public static string BuildArgumentValue(object value, string formatMask, GraphQlBuilderOptions options, int level)
@@ -163,7 +165,7 @@ internal static class GraphQlQueryHelper
         if (!String.IsNullOrEmpty(formatMask) && enumerable == null)
             return
                 value is IFormattable formattable
-                    ? $"\"{EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))}\""
+                    ? EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))
                     : throw new ArgumentException($"Value must implement {nameof(IFormattable)} interface to use a format mask. ", nameof(value));
 
         if (value is Enum @enum)
@@ -173,19 +175,19 @@ internal static class GraphQlQueryHelper
             return @bool ? "true" : "false";
 
         if (value is DateTime dateTime)
-            return $"\"{dateTime.ToString("O")}\"";
+            return EscapeGraphQlStringValue(dateTime.ToString("O"));
 
         if (value is DateTimeOffset dateTimeOffset)
-            return $"\"{dateTimeOffset.ToString("O")}\"";
+            return EscapeGraphQlStringValue(dateTimeOffset.ToString("O"));
 
         if (value is IGraphQlInputObject inputObject)
             return BuildInputObject(inputObject, options, level + 2);
 
-        if (value is Guid)
-            return $"\"{value}\"";
+        if (value is Guid guid)
+            return EscapeGraphQlStringValue(guid.ToString("D"));
 
         if (value is String @string)
-            return $"\"{EscapeGraphQlStringValue(@string)}\"";
+            return EscapeGraphQlStringValue(@string);
 
         if (enumerable != null)
             return BuildEnumerableArgument(enumerable, formatMask, options, level, '[', ']');
@@ -194,7 +196,7 @@ internal static class GraphQlQueryHelper
             return Convert.ToString(value, CultureInfo.InvariantCulture);
 
         var argumentValue = EscapeGraphQlStringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
-        return $"\"{argumentValue}\"";
+        return argumentValue;
     }
 
     public static string BuildEnumerableArgument(IEnumerable enumerable, string formatMask, GraphQlBuilderOptions options, int level, char openingSymbol, char closingSymbol)
@@ -359,7 +361,7 @@ public class DefaultGraphQlArgumentBuilder : IGraphQlArgumentBuilder
                     return true;
 
                 case JTokenType.String:
-                    graphQlString = $"\"{GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value)}\"";
+                    graphQlString = GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value);
                     return true;
 
                 default:

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/FullClientCSharpFile
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/FullClientCSharpFile
@@ -167,7 +167,9 @@ namespace GraphQlGenerator.Test
     
         public static string EscapeGraphQlStringValue(string value)
         {
-            return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            var escaped = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    
+            return $"\"\"\"{escaped}\"\"\"";
         }
     
         public static string BuildArgumentValue(object value, string formatMask, GraphQlBuilderOptions options, int level)
@@ -183,7 +185,7 @@ namespace GraphQlGenerator.Test
             if (!String.IsNullOrEmpty(formatMask) && enumerable == null)
                 return
                     value is IFormattable formattable
-                        ? $"\"{EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))}\""
+                        ? EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))
                         : throw new ArgumentException($"Value must implement {nameof(IFormattable)} interface to use a format mask. ", nameof(value));
     
             if (value is Enum @enum)
@@ -193,19 +195,19 @@ namespace GraphQlGenerator.Test
                 return @bool ? "true" : "false";
     
             if (value is DateTime dateTime)
-                return $"\"{dateTime.ToString("O")}\"";
+                return EscapeGraphQlStringValue(dateTime.ToString("O"));
     
             if (value is DateTimeOffset dateTimeOffset)
-                return $"\"{dateTimeOffset.ToString("O")}\"";
+                return EscapeGraphQlStringValue(dateTimeOffset.ToString("O"));
     
             if (value is IGraphQlInputObject inputObject)
                 return BuildInputObject(inputObject, options, level + 2);
     
-            if (value is Guid)
-                return $"\"{value}\"";
+            if (value is Guid guid)
+                return EscapeGraphQlStringValue(guid.ToString("D"));
     
             if (value is String @string)
-                return $"\"{EscapeGraphQlStringValue(@string)}\"";
+                return EscapeGraphQlStringValue(@string);
     
             if (enumerable != null)
                 return BuildEnumerableArgument(enumerable, formatMask, options, level, '[', ']');
@@ -214,7 +216,7 @@ namespace GraphQlGenerator.Test
                 return Convert.ToString(value, CultureInfo.InvariantCulture);
     
             var argumentValue = EscapeGraphQlStringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
-            return $"\"{argumentValue}\"";
+            return argumentValue;
         }
     
         public static string BuildEnumerableArgument(IEnumerable enumerable, string formatMask, GraphQlBuilderOptions options, int level, char openingSymbol, char closingSymbol)
@@ -379,7 +381,7 @@ namespace GraphQlGenerator.Test
                         return true;
     
                     case JTokenType.String:
-                        graphQlString = $"\"{GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value)}\"";
+                        graphQlString = GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value);
                         return true;
     
                     default:

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResult
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResult
@@ -167,7 +167,9 @@ namespace SourceGeneratorTestAssembly
     
         public static string EscapeGraphQlStringValue(string value)
         {
-            return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            var escaped = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    
+            return $"\"\"\"{escaped}\"\"\"";
         }
     
         public static string BuildArgumentValue(object value, string formatMask, GraphQlBuilderOptions options, int level)
@@ -183,7 +185,7 @@ namespace SourceGeneratorTestAssembly
             if (!String.IsNullOrEmpty(formatMask) && enumerable == null)
                 return
                     value is IFormattable formattable
-                        ? $"\"{EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))}\""
+                        ? EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))
                         : throw new ArgumentException($"Value must implement {nameof(IFormattable)} interface to use a format mask. ", nameof(value));
     
             if (value is Enum @enum)
@@ -193,19 +195,19 @@ namespace SourceGeneratorTestAssembly
                 return @bool ? "true" : "false";
     
             if (value is DateTime dateTime)
-                return $"\"{dateTime.ToString("O")}\"";
+                return EscapeGraphQlStringValue(dateTime.ToString("O"));
     
             if (value is DateTimeOffset dateTimeOffset)
-                return $"\"{dateTimeOffset.ToString("O")}\"";
+                return EscapeGraphQlStringValue(dateTimeOffset.ToString("O"));
     
             if (value is IGraphQlInputObject inputObject)
                 return BuildInputObject(inputObject, options, level + 2);
     
-            if (value is Guid)
-                return $"\"{value}\"";
+            if (value is Guid guid)
+                return EscapeGraphQlStringValue(guid.ToString("D"));
     
             if (value is String @string)
-                return $"\"{EscapeGraphQlStringValue(@string)}\"";
+                return EscapeGraphQlStringValue(@string);
     
             if (enumerable != null)
                 return BuildEnumerableArgument(enumerable, formatMask, options, level, '[', ']');
@@ -214,7 +216,7 @@ namespace SourceGeneratorTestAssembly
                 return Convert.ToString(value, CultureInfo.InvariantCulture);
     
             var argumentValue = EscapeGraphQlStringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
-            return $"\"{argumentValue}\"";
+            return argumentValue;
         }
     
         public static string BuildEnumerableArgument(IEnumerable enumerable, string formatMask, GraphQlBuilderOptions options, int level, char openingSymbol, char closingSymbol)
@@ -379,7 +381,7 @@ namespace SourceGeneratorTestAssembly
                         return true;
     
                     case JTokenType.String:
-                        graphQlString = $"\"{GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value)}\"";
+                        graphQlString = GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value);
                         return true;
     
                     default:

--- a/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResultWithFileScopedNamespaces
+++ b/test/GraphQlClientGenerator.Test/ExpectedSingleFileGenerationContext/SourceGeneratorResultWithFileScopedNamespaces
@@ -167,7 +167,9 @@ internal static class GraphQlQueryHelper
 
     public static string EscapeGraphQlStringValue(string value)
     {
-        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        var escaped = value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+        return $"\"\"\"{escaped}\"\"\"";
     }
 
     public static string BuildArgumentValue(object value, string formatMask, GraphQlBuilderOptions options, int level)
@@ -183,7 +185,7 @@ internal static class GraphQlQueryHelper
         if (!String.IsNullOrEmpty(formatMask) && enumerable == null)
             return
                 value is IFormattable formattable
-                    ? $"\"{EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))}\""
+                    ? EscapeGraphQlStringValue(formattable.ToString(formatMask, CultureInfo.InvariantCulture))
                     : throw new ArgumentException($"Value must implement {nameof(IFormattable)} interface to use a format mask. ", nameof(value));
 
         if (value is Enum @enum)
@@ -193,19 +195,19 @@ internal static class GraphQlQueryHelper
             return @bool ? "true" : "false";
 
         if (value is DateTime dateTime)
-            return $"\"{dateTime.ToString("O")}\"";
+            return EscapeGraphQlStringValue(dateTime.ToString("O"));
 
         if (value is DateTimeOffset dateTimeOffset)
-            return $"\"{dateTimeOffset.ToString("O")}\"";
+            return EscapeGraphQlStringValue(dateTimeOffset.ToString("O"));
 
         if (value is IGraphQlInputObject inputObject)
             return BuildInputObject(inputObject, options, level + 2);
 
-        if (value is Guid)
-            return $"\"{value}\"";
+        if (value is Guid guid)
+            return EscapeGraphQlStringValue(guid.ToString("D"));
 
         if (value is String @string)
-            return $"\"{EscapeGraphQlStringValue(@string)}\"";
+            return EscapeGraphQlStringValue(@string);
 
         if (enumerable != null)
             return BuildEnumerableArgument(enumerable, formatMask, options, level, '[', ']');
@@ -214,7 +216,7 @@ internal static class GraphQlQueryHelper
             return Convert.ToString(value, CultureInfo.InvariantCulture);
 
         var argumentValue = EscapeGraphQlStringValue(Convert.ToString(value, CultureInfo.InvariantCulture));
-        return $"\"{argumentValue}\"";
+        return argumentValue;
     }
 
     public static string BuildEnumerableArgument(IEnumerable enumerable, string formatMask, GraphQlBuilderOptions options, int level, char openingSymbol, char closingSymbol)
@@ -379,7 +381,7 @@ public class DefaultGraphQlArgumentBuilder : IGraphQlArgumentBuilder
                     return true;
 
                 case JTokenType.String:
-                    graphQlString = $"\"{GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value)}\"";
+                    graphQlString = GraphQlQueryHelper.EscapeGraphQlStringValue((string)jValue.Value);
                     return true;
 
                 default:

--- a/test/GraphQlClientGenerator.Test/GraphQlClientSourceGeneratorTest.cs
+++ b/test/GraphQlClientGenerator.Test/GraphQlClientSourceGeneratorTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -45,7 +46,7 @@ public class GraphQlClientSourceGeneratorTest : IDisposable
         var generatedSource = GenerateSource(null, scalarFieldTypeMappingProviderTypeName, useFileScopedNamespace);
 
         generatedSource.Encoding.ShouldBe(Encoding.UTF8);
-        var sourceCode = generatedSource.ToString();
+        var sourceCode = generatedSource.ToString().NormalizeLineEndings();
 
         var expectedSourceCode = GetExpectedSourceText(expectedResultResourceName);
         sourceCode.ShouldBe(expectedSourceCode);
@@ -55,7 +56,7 @@ public class GraphQlClientSourceGeneratorTest : IDisposable
     public void SourceGenerationWithRegexCustomScalarFieldTypeMappingProvider()
     {
         var generatedSource = GenerateSource(_fileMappingRules, null, false);
-        var sourceCode = generatedSource.ToString();
+        var sourceCode = generatedSource.ToString().NormalizeLineEndings();
 
         var expectedSourceCode = GetExpectedSourceText("SourceGeneratorResult").Replace("typeof(DateTimeOffset)", "typeof(DateTime)").Replace("DateTimeOffset?", "DateTime?");
         sourceCode.ShouldBe(expectedSourceCode);
@@ -64,7 +65,7 @@ public class GraphQlClientSourceGeneratorTest : IDisposable
     private static string GetExpectedSourceText(string expectedResultsFile)
     {
         using var reader = new StreamReader(typeof(GraphQlGeneratorTest).Assembly.GetManifestResourceStream($"GraphQlClientGenerator.Test.ExpectedSingleFileGenerationContext.{expectedResultsFile}"));
-        return reader.ReadToEnd();
+        return reader.ReadToEnd().NormalizeLineEndings();
     }
 
     private SourceText GenerateSource(AdditionalText additionalFile, string scalarFieldTypeMappingProviderTypeName, bool useFileScopedNamespaces)

--- a/test/GraphQlClientGenerator.Test/StringExtensions.cs
+++ b/test/GraphQlClientGenerator.Test/StringExtensions.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+
+namespace GraphQlClientGenerator.Test;
+
+public static class StringExtensions
+{
+    public static string NormalizeLineEndings(this string source, string lineEnding = "\r\n")
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return Regex.Replace(source, @"\r\n?|\n", lineEnding);
+    }
+}


### PR DESCRIPTION
There's probably a more elegant way to accomplish this, but it's working for me.  
I don't see any test coverage for the BaseClasses resource, but point me in that direction if I'm wrong.