### PR TITLE
Support for NonNull GraphQL types RegexScalarFieldTypeMappingProvider

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Copyright>Copyright 2017-2024</Copyright>
     <Authors>Husqvik</Authors>
     <Company>Tibber</Company>
-    <VersionPrefix>0.9.24</VersionPrefix>
+    <VersionPrefix>0.9.25</VersionPrefix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Husqvik/GraphQlClientGenerator</PackageProjectUrl>
     <PackageIcon>GraphQlLogo.png</PackageIcon>

--- a/src/GraphQlClientGenerator.Console/GraphQlClientGenerator.Console.csproj
+++ b/src/GraphQlClientGenerator.Console/GraphQlClientGenerator.Console.csproj
@@ -10,7 +10,7 @@
     <PackageTags>GraphQL Client Generator Tool Console</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-      Introduced --generationOrder parameter
+       Support for NonNull GraphQL types RegexScalarFieldTypeMappingProvider
       ]]>
     </PackageReleaseNotes>
     <PackAsTool>true</PackAsTool>

--- a/src/GraphQlClientGenerator/RegexScalarFieldTypeMappingProvider.cs
+++ b/src/GraphQlClientGenerator/RegexScalarFieldTypeMappingProvider.cs
@@ -26,11 +26,11 @@ public class RegexScalarFieldTypeMappingProvider : IScalarFieldTypeMappingProvid
 
             if (Regex.IsMatch(valueName, rule.PatternValueName) &&
                 Regex.IsMatch(baseType.Name, rule.PatternBaseType) &&
-                Regex.IsMatch((expectNonNullType ? $"{unwrappedValueType.Name}!" : valueType.Name) ?? String.Empty, rule.PatternValueType))
+                Regex.IsMatch((expectNonNullType ? $"{unwrappedValueType.Name}!" : unwrappedValueType.Name) ?? String.Empty, rule.PatternValueType))
                 return new ScalarFieldTypeDescription { NetTypeName = rule.NetTypeName, FormatMask = rule.FormatMask };
         }
 
-        return DefaultScalarFieldTypeMappingProvider.GetFallbackFieldType(configuration, valueType);
+        return DefaultScalarFieldTypeMappingProvider.GetFallbackFieldType(configuration, unwrappedValueType);
     }
 }
 

--- a/src/GraphQlClientGenerator/RegexScalarFieldTypeMappingProvider.cs
+++ b/src/GraphQlClientGenerator/RegexScalarFieldTypeMappingProvider.cs
@@ -18,15 +18,15 @@ public class RegexScalarFieldTypeMappingProvider : IScalarFieldTypeMappingProvid
 
     public ScalarFieldTypeDescription GetCustomScalarFieldType(GraphQlGeneratorConfiguration configuration, GraphQlType baseType, GraphQlTypeBase valueType, string valueName)
     {
-        valueType = (valueType as GraphQlFieldType)?.UnwrapIfNonNull() ?? valueType;
+        var unwrappedValueType = (valueType as GraphQlFieldType)?.UnwrapIfNonNull() ?? valueType;
 
         foreach (var rule in _rules)
         {
-            var expectNonNullType = rule.PatternValueType.EndsWith("!");
+            var expectNonNullType = unwrappedValueType != valueType && rule.PatternValueType.EndsWith("!");
 
             if (Regex.IsMatch(valueName, rule.PatternValueName) &&
                 Regex.IsMatch(baseType.Name, rule.PatternBaseType) &&
-                Regex.IsMatch((expectNonNullType ? $"{valueType.Name}!" : valueType.Name) ?? String.Empty, rule.PatternValueType))
+                Regex.IsMatch((expectNonNullType ? $"{unwrappedValueType.Name}!" : valueType.Name) ?? String.Empty, rule.PatternValueType))
                 return new ScalarFieldTypeDescription { NetTypeName = rule.NetTypeName, FormatMask = rule.FormatMask };
         }
 

--- a/src/GraphQlClientGenerator/RegexScalarFieldTypeMappingProvider.cs
+++ b/src/GraphQlClientGenerator/RegexScalarFieldTypeMappingProvider.cs
@@ -21,10 +21,14 @@ public class RegexScalarFieldTypeMappingProvider : IScalarFieldTypeMappingProvid
         valueType = (valueType as GraphQlFieldType)?.UnwrapIfNonNull() ?? valueType;
 
         foreach (var rule in _rules)
+        {
+            var expectNonNullType = rule.PatternValueType.EndsWith("!");
+
             if (Regex.IsMatch(valueName, rule.PatternValueName) &&
                 Regex.IsMatch(baseType.Name, rule.PatternBaseType) &&
-                Regex.IsMatch(valueType.Name ?? String.Empty, rule.PatternValueType))
+                Regex.IsMatch((expectNonNullType ? $"{valueType.Name}!" : valueType.Name) ?? String.Empty, rule.PatternValueType))
                 return new ScalarFieldTypeDescription { NetTypeName = rule.NetTypeName, FormatMask = rule.FormatMask };
+        }
 
         return DefaultScalarFieldTypeMappingProvider.GetFallbackFieldType(configuration, valueType);
     }

--- a/test/GraphQlClientGenerator.Test/RegexCustomScalarFieldTypeMappingRules
+++ b/test/GraphQlClientGenerator.Test/RegexCustomScalarFieldTypeMappingRules
@@ -5,5 +5,17 @@
     "patternValueName": "^((timestamp)|(.*(f|F)rom)|(.*(t|T)o))$",
     "netTypeName": "DateTime?",
     "formatMask": "O"
+  },
+  {
+    "patternBaseType": ".+",
+    "patternValueType": "Long!",
+    "patternValueName": ".+",
+    "netTypeName": "long"
+  },
+  {
+    "patternBaseType": ".+",
+    "patternValueType": "Long",
+    "patternValueName": ".+",
+    "netTypeName": "long?"
   }
 ]


### PR DESCRIPTION
Proposal to add nullability support to `RegexScalarFieldTypeMappingProvider`.

Let's see an example:
```
  {
    "patternBaseType": ".+",
    "patternValueType": "Long!",
    "patternValueName": ".+",
    "netTypeName": "long"
  },
  {
    "patternBaseType": ".+",
    "patternValueType": "Long",
    "patternValueName": ".+",
    "netTypeName": "long?"
  },
```

Currently, when processing a rule, a GraphQL NonNull type is converted to Nullable type(`Long! -> Long`), 
`valueType = (valueType as GraphQlFieldType)?.UnwrapIfNonNull() ?? valueType;`
so the first rule is always skipped, and the second is executed, generating a .NET type `long?` instead of `long`.

This PR will allow more flexible control over type generation and maintain backward compatibility.